### PR TITLE
Remove call to invalid `setup_target_libs` CMake function/macro

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,4 +8,3 @@ set(SOURCE_FILES
 )
 
 add_library(${PROJECT_NAME} ${SOURCE_FILES})
-setup_target_libs(${PROJECT_NAME})


### PR DESCRIPTION
According to Google there is no such CMake function/macro, and CMake (recent version) fails when executing the CMakeLists.txt script. It might be an artefact from the project this was originally created for(?). This pull request simply removes that line.

Thanks!

// Simon